### PR TITLE
When using **, stream topic must rewrite it to */** so it contains a server and topic

### DIFF
--- a/stream_topic.js
+++ b/stream_topic.js
@@ -44,6 +44,11 @@ StreamTopic.prototype.parse = function(topicString){
     return;
   }
 
+  // Reformat topic string to have server as * the topic as **
+  if (topicString === '**') {
+    topicString = '*/**';
+  }
+
   // seperate streamQuery from topic
   var seperated = this._seperateStreamQuery(topicString);
   this._mm = new Minimatch(seperated.topic, { nobrace: false, dot: true, noext: true });
@@ -59,7 +64,6 @@ StreamTopic.prototype.parse = function(topicString){
     // ** star case, make regexp to match everything
     this._serverName = '*';
   }
-
 
   // Join the rest of the topic for the pubsub identifier without the servername
   var arr = [];


### PR DESCRIPTION
This ensures when you only add `**` as a topic the streamTopic has both a pubsub piece and a server which is `*`.
