### PR TITLE
Take into account leading **

### DIFF
--- a/stream_topic.js
+++ b/stream_topic.js
@@ -63,6 +63,13 @@ StreamTopic.prototype.parse = function(topicString){
   } else if (typeof serverName === 'object' && Object.keys(serverName).length === 0) {
     // ** star case, make regexp to match everything
     this._serverName = '*';
+
+    // Handle cases with leading **/some-topic
+    // Check to make sure there is something after ** and make sure it's not just **/
+    // If full topic is specified after ** dont add ** to begening. eg. "**/led/123/state"
+    if (this._mm.set[0].length > 1 && this._mm.set[0].length < 4 && this._mm.set[0][1] !== '') {
+      this._mm.set[0].unshift({});
+    }
   }
 
   // Join the rest of the topic for the pubsub identifier without the servername


### PR DESCRIPTION
PR to handle cases with leading double star. For all cases except when full topic is specified after *\* StreamTopic will add a *\* to the beginning of the pubsub topic.

```
**/ -> Will fail as nothing to match on after server name.
**/some-topic -> ServerName=* Topic="**/some-topic"
**/1234/state -> ServerName=* Topic="**/1234/state"
**/led/1234/state -> ServerName=* Topic="led/1234/state" Will not expand if a full topic is specified after the **.
```
